### PR TITLE
Add rate limiter, encryption to admin login.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cookie-parser": "^1.4.3",
     "dotenv": "^6.0.0",
     "email-templates": "^6.0.0",
+    "envfile": "^6.14.0",
     "express": "^4.16.3",
     "express-rate-limit": "^5.2.3",
     "express-session": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react-router-dom": "5.1.2",
     "react-scripts": "2.0.3",
     "react-stripe-elements": "^1.6.0",
-    "react-swipeable-views": "^0.12.15",
+    "react-swipeable-views": "^0.13.9",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "rimraf": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^4.8.0",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.37",
+    "bcrypt": "^5.0.0",
     "connected-react-router": "^6.6.1",
     "cookie-parser": "^1.4.3",
     "dotenv": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^6.0.0",
     "email-templates": "^6.0.0",
     "express": "^4.16.3",
+    "express-rate-limit": "^5.2.3",
     "express-session": "^1.15.6",
     "fs": "^0.0.1-security",
     "fs-extra": "^8.1.0",

--- a/server/admin.js
+++ b/server/admin.js
@@ -1,6 +1,7 @@
 const app = require('./index.js');
 const stripe = require("stripe")(process.env.STRIPE_KEY);
 const rateLimit = require('express-rate-limit');
+const bcrypt = require('bcrypt');
 
 // Enable if you're behind a reverse proxy (Heroku, Bluemix, AWS ELB, Nginx, etc)
 // // see https://expressjs.com/en/guide/behind-proxies.html
@@ -14,16 +15,18 @@ const apiLimiter = rateLimit({
 app.use('/api/login', apiLimiter);
 
 app.post('/api/login', function(req, res) {
-  if (req.body.password === process.env.ADMIN_PW) {
-    req.session.isAdmin = true;
-    res.json({ isAdmin: true })
-  } else {
-    res.status(401).json({
-      error: {
-        message: 'Wrong password!'
-      }
-    });
-  }
+  bcrypt.compare(req.body.passowrd, process.env.ADMIN_PW, (err, result) => {
+	if ( result === true ) {
+		req.session.isAdmin = true;
+		res.json({ isAdmin: true })
+	} else {
+		res.status(401).json({
+			error: {
+				message: 'Wrong password!'
+			}
+		})
+	}
+  });
 });
 
 app.get('/api/logout', function(req, res) {

--- a/server/admin.js
+++ b/server/admin.js
@@ -40,7 +40,7 @@ const apiLimiter = rateLimit({
 app.use('/api/login', apiLimiter);
 
 app.post('/api/login', function(req, res) {
-  bcrypt.compare(req.body.passowrd, process.env.ADMIN_PW, (err, result) => {
+  bcrypt.compare(req.body.password, process.env.ADMIN_PW, (err, result) => {
 	if ( result === true ) {
 		req.session.isAdmin = true;
 		res.json({ isAdmin: true })

--- a/server/admin.js
+++ b/server/admin.js
@@ -1,5 +1,17 @@
 const app = require('./index.js');
 const stripe = require("stripe")(process.env.STRIPE_KEY);
+const rateLimit = require('express-rate-limit');
+
+// Enable if you're behind a reverse proxy (Heroku, Bluemix, AWS ELB, Nginx, etc)
+// // see https://expressjs.com/en/guide/behind-proxies.html
+// // app.set('trust proxy', 1);
+
+const apiLimiter = rateLimit({
+	windowMs: process.env.LOGIN_LIMIT_TIME_PERIOD || 15 * 1000,
+	max: process.env.LOGIN_REQUESTS_PER_PERIOD || 1
+});
+
+app.use('/api/login', apiLimiter);
 
 app.post('/api/login', function(req, res) {
   if (req.body.password === process.env.ADMIN_PW) {

--- a/server/admin.js
+++ b/server/admin.js
@@ -11,7 +11,7 @@ if ( !process.env.ADMIN_PW ){
 	throw 'ADMIN_PW must be provided in config.env';
 }
 
-if ( !process.env.HASHED || process.env.HASHED !== 'true' ){
+if ( !process.env.PASSWORD_IS_HASHED || process.env.PASSWORD_IS_HASHED !== 'true' ){
 	bcrypt.hash(process.env.ADMIN_PW, saltRounds, function(err, hash) {
 		fs.readFile(pathToenvFile, {encoding:'utf8', flag:'r'}, function(err, data) {
 			if(err) {
@@ -19,9 +19,9 @@ if ( !process.env.HASHED || process.env.HASHED !== 'true' ){
 			}
 			let result = parse(data);
 			result['ADMIN_PW'] = hash;
-			result['HASHED'] = 'true';
+			result['PASSWORD_IS_HASHED'] = 'true';
 			process.env['ADMIN_PW'] = hash;
-			process.env['HASHED'] = 'true';	
+			process.env['PASSWORD_IS_HASHED'] = 'true';	
 
 			fs.writeFile(pathToenvFile, stringify(result), function (err) {
 				if (err) {

--- a/server/admin.js
+++ b/server/admin.js
@@ -7,29 +7,27 @@ const { parse, stringify } = require('envfile');
 const pathToenvFile = 'config.env';
 const saltRounds = 13;
 
-if ( !process.env.ADMIN_PW ){
-	throw 'ADMIN_PW must be provided in config.env';
-}
-
 if ( !process.env.PASSWORD_IS_HASHED || process.env.PASSWORD_IS_HASHED !== 'true' ){
-	bcrypt.hash(process.env.ADMIN_PW, saltRounds, function(err, hash) {
-		fs.readFile(pathToenvFile, {encoding:'utf8', flag:'r'}, function(err, data) {
-			if(err) {
-				console.log(err);
-			}
-			let result = parse(data);
-			result['ADMIN_PW'] = hash;
-			result['PASSWORD_IS_HASHED'] = 'true';
-			process.env['ADMIN_PW'] = hash;
-			process.env['PASSWORD_IS_HASHED'] = 'true';	
-
-			fs.writeFile(pathToenvFile, stringify(result), function (err) {
-				if (err) {
+	if ( process.env.ADMIN_PW ){
+		bcrypt.hash(process.env.ADMIN_PW, saltRounds, function(err, hash) {
+			fs.readFile(pathToenvFile, {encoding:'utf8', flag:'r'}, function(err, data) {
+				if(err) {
 					console.log(err);
 				}
+				let result = parse(data);
+				result['ADMIN_PW'] = hash;
+				result['PASSWORD_IS_HASHED'] = 'true';
+				process.env['ADMIN_PW'] = hash;
+				process.env['PASSWORD_IS_HASHED'] = 'true';	
+
+				fs.writeFile(pathToenvFile, stringify(result), function (err) {
+					if (err) {
+						console.log(err);
+					}
+				});
 			});
 		});
-	});
+	}
 }
 
 const apiLimiter = rateLimit({
@@ -41,7 +39,7 @@ app.use('/api/login', apiLimiter);
 
 app.post('/api/login', function(req, res) {
   bcrypt.compare(req.body.password, process.env.ADMIN_PW, (err, result) => {
-	if ( result === true ) {
+	if ( process.env.ADMIN_PW && result === true ) {
 		req.session.isAdmin = true;
 		res.json({ isAdmin: true })
 	} else {


### PR DESCRIPTION
- ✋Added limiter to login route.
-By default the limit is 1 request per 15 seconds but these can both be modified with the LOGIN_LIMIT_TIME_PERIOD and LOGIN_REQUESTS_PER_PERIOD respectively. 

- 🔑 Added an encryption to the admin login
-Setting password is unmodified 
-If user wants to change password, they should also delete the PASSWORD_IS_HASHED variable from config.env