### PR TITLE
pagination on the order page

### DIFF
--- a/server/admin.js
+++ b/server/admin.js
@@ -63,9 +63,9 @@ app.get('/api/logout', function(req, res) {
 })
 
 
-app.get('/orders/:status', function(req, res) {
+app.post('/list-orders', function(req, res) {
   if (req.session.isAdmin || app.get('env') === "development") {
-    stripe.orders.list({ status: req.params.status },
+    stripe.orders.list(req.body,
       function(err, orders) {
         if (orders) res.json(orders.data);
       });

--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,7 @@ import Confirm from './components/checkout/Confirm';
 import Config from "./routes/Config";
 
 import InitialConfig from "./components/config/InitialConfig";
-import Admin from './components/admin/Admin';
+import Orders from './components/admin/Orders';
 import Login from './components/admin/Login';
 
 import NotFound404 from "./components/NotFound404"
@@ -143,7 +143,7 @@ function App(props) {
                 } />
               )}
               {isAdmin && (
-                <Route exact path="/admin" component={Admin} />
+                <Route exact path="/orders" component={Orders} />
               )}
             
               <Route component={NotFound404} />

--- a/src/components/admin/Login.js
+++ b/src/components/admin/Login.js
@@ -28,7 +28,7 @@ function Login(props) {
           if (props.history.location.search)
             props.history.push(`/${props.history.location.search.split("?")[1]}`)
           else
-            props.history.push("/admin");
+            props.history.push("/orders");
 
         } else if (json.error)
           setError(json.error.message)

--- a/src/components/admin/OrderTable.js
+++ b/src/components/admin/OrderTable.js
@@ -31,7 +31,7 @@ const Status = styled.div `
   }}
 `;
 
-const AdminTable = (props) => {
+const OrderTable = (props) => {
   const getStatus = status => (
     <Status state={status}>{status.charAt(0)}</Status>
   );
@@ -125,4 +125,4 @@ const AdminTable = (props) => {
     </div>
   );
 };
-export default AdminTable;
+export default OrderTable;

--- a/src/components/admin/Orders.js
+++ b/src/components/admin/Orders.js
@@ -1,25 +1,45 @@
 import React, { useState, useEffect } from 'react';
+import styled from "styled-components";
 import { withRouter } from "react-router-dom";
 
 import { useDispatch } from "react-redux";
 
-import AdminTable from './AdminTable';
+import OrderTable from './OrderTable';
 import PageWrapper from '../ui/PageWrapper';
 import { Paper, Button } from "@material-ui/core";
 
-function Admin(props) {
+const PaginationUI = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid #888;
+  margin: 20px 20px 0;
+  padding: 10px 0;
+`;
+
+function Orders(props) {
   const [viewStatus, setViewStatus] = useState("paid");
   const [orders, setOrders] = useState([]);
+
+  const [starting_after, setStartingAfter] = useState(null);
+  const [ending_before, setEndingBefore] = useState(null);
+  const ordersPerPage = 10;
 
   const dispatch = useDispatch();
 
   useEffect(() => {
-    getOrders(viewStatus);
+    const postBody = { status: viewStatus, limit: ordersPerPage };
+    getOrders(postBody);
   }, [viewStatus])
 
-  const getOrders = status => {
-    fetch('/orders/' + status, {
-        credentials: 'same-origin',
+  
+  const getOrders = (postBody, pagination) => {
+    // passing in a pagination variable if we are attempting to paginate
+
+    fetch('/list-orders', {
+        method: 'POST',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        body: JSON.stringify(postBody)
       }).then(res => {
         if (res.redirected)
           props.history.push('/login');
@@ -27,20 +47,54 @@ function Admin(props) {
           return res.json();
       })
       .then(results => {
-        if (!results) return;
-
         if (results.error) {
           logout();
-        } else {
-          const newOrders = results.map(r => {
-            r["display_status"] = r.metadata.status || "Ordered";
-            r["display_tracking"] = "";
-            return r;
-          })
 
-          setOrders(newOrders);
+        } else if (!results.length) {
+          // if we reached no more orders, do nothing
+          if (pagination) return;
+          // else there are no orders with this status, show empty array
+          else setOrders([]);
+
+        } else if (results.length < ordersPerPage) {
+          // at the end of our list
+          processOrders(results);
+          setStartingAfter(null);
+          setEndingBefore(results[0].id);
+          
+        } else {
+          processOrders(results);
+          setStartingAfter(results[results.length - 1].id);
+          if (pagination)
+            setEndingBefore(results[0].id);
         }
       });
+  }
+
+  const processOrders = results => {
+    const newOrders = results.map(r => {
+      r["display_status"] = r.metadata.status || "Ordered";
+      r["display_tracking"] = "";
+      return r;
+    })
+    setOrders(newOrders);
+  }
+
+  const getNextOrders = () => {
+    const postBody = {
+      status: viewStatus,
+      limit: ordersPerPage,
+      ending_before: orders[0].id
+    };
+    getOrders(postBody, true)
+  }
+  const getPrevOrders = () => {
+    const postBody = {
+      status: viewStatus,
+      limit: ordersPerPage,
+      starting_after: orders[orders.length - 1].id
+    };
+    getOrders(postBody, true)
   }
 
   const logout = () => {
@@ -105,8 +159,11 @@ function Admin(props) {
       <Paper style={{ position: "relative "}}>
         <Button color="primary" onClick={logout}
           style={{ position: "absolute", right: "20px", top: "10px", zIndex: "1" }}
-        >Logout</Button>
-        <AdminTable 
+        >
+          Logout
+        </Button>
+
+        <OrderTable 
           view_status={viewStatus}
           orders={orders}
           updateOrder={updateOrder}
@@ -114,8 +171,17 @@ function Admin(props) {
           updateStatus={updateStatus}
           switchView={setViewStatus}
         />
+
+        <PaginationUI>
+          <Button color="primary" onClick={getNextOrders} disabled={!ending_before}>
+            ← Next
+          </Button>
+          <Button color="primary" onClick={getPrevOrders} disabled={!starting_after}>
+            Prev →
+          </Button>
+        </PaginationUI>
       </Paper>
     </PageWrapper>
   );
 };
-export default withRouter(Admin);
+export default withRouter(Orders);

--- a/src/components/ui/Banner.js
+++ b/src/components/ui/Banner.js
@@ -46,7 +46,7 @@ function Banner({ classes, quantity, config, width }) {
 
   if (isAdmin) {
     links.push({ url: "/config", label: "Config" })
-    links.push({ url: "/admin", label: "Orders" })
+    links.push({ url: "/orders", label: "Orders" })
   }
 
   const renderLinks = (link, i) => (


### PR DESCRIPTION
![Screen Shot 2020-12-22 at 3 29 23 PM](https://user-images.githubusercontent.com/589151/102939021-4df02680-4462-11eb-8756-edc7ec422afe.png)
added Prev and Next buttons to the order page, which paginate through orders

also renamed "Admin" to "Orders", since there are multiple admin pages (i.e. Config)